### PR TITLE
Änderungen zur Unterstützung des Futro S700 (S26361-K1040-v100).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## USB-Stick - Gluon2Futro (Win/Linux/OS X)
-#### Neu: Jetzt auch mit Futro S720  und Wyse R90LE(W) Unterstützung!
+#### Neu: Jetzt auch mit Futro S700, S720 und Wyse R90LE(W) Unterstützung!
 
-Mit Hilfe dieses Projektes kann, ohne das Gehäuse öffnen zu müssen, ein beliebiges Freifunk Gluon-x86-Image auf die interne CF-Karte eines Futro S550, S550-2, S720 oder eines Wyse R90LE(W) übertragen werden.
+Mit Hilfe dieses Projektes kann, ohne das Gehäuse öffnen zu müssen, ein beliebiges Freifunk Gluon-x86-Image auf die interne CF-Karte eines Futro S550, S550-2, S700, S720 oder eines Wyse R90LE(W) übertragen werden.
 
 Es wird lediglich ein USB-Stick benötigt.
 

--- a/interna/bitte_nicht_loeschen.sh
+++ b/interna/bitte_nicht_loeschen.sh
@@ -94,17 +94,21 @@ else
       if (grep -Fq "AMD GX-217GA" /proc/cpuinfo) ; then
         echo "AMD GX-217GA Prozessor gefunden -> Futro S720"
       else
-        echo
-        echo Fehler:
-        echo Kein Futro S550, S550-2, S720 oder Wyse R90LE.
-        echo
-        echo Fehlergrund:
-        echo Keinen AMD Sempron 2100+, 200U, 210U oder GX-217GA gefunden.
-        echo
-        echo Abbruch!
-        echo
-        sleep 3
-        exit 1
+        if (grep -Fq "AMD G-T44R Processor" /proc/cpuinfo) ; then
+          echo "AMD G-T44R Processor Prozessor gefunden -> Futro S700"
+        else
+          echo
+          echo Fehler:
+          echo Kein Futro S550, S550-2, S700, S720 oder Wyse R90LE.
+          echo
+          echo Fehlergrund:
+          echo Keinen AMD Sempron 2100+, 200U, 210U, G-T44R oder GX-217GA gefunden.
+          echo
+          echo Abbruch!
+          echo
+          sleep 3
+          exit 1
+        fi
       fi
     fi
   fi

--- a/interna/start.sh
+++ b/interna/start.sh
@@ -31,13 +31,13 @@ echo
 echo
 echo "################################################################################"
 echo "#                                                                              #"
-echo "#                       GLUON auf Futro S550 Autoinstaller                     #"
+echo "#                       GLUON auf Futro Sxxx Autoinstaller                     #"
 echo "#                                                                              #"
 echo "################################################################################"
 echo
 echo
 
-mount /dev/sdb1
+mount /dev/sdb1 || mount /dev/sdc1
 if [ $? != "0" ]; then
   echo Fehler: Kann USB-Partition mit Gluon-Image-Datei nicht einbinden!
   echo Abbruch!
@@ -50,16 +50,18 @@ else
 fi
 echo
 
-cd /mnt/sdb1
+cd /mnt/sdb1 || cd /mnt/sdc1
 
 /bin/sh bitte_nicht_loeschen.sh
 
 if [ $? != "0" ]; then
   cd
-  sudo umount /mnt/sdb1
+  sudo umount /mnt/sdb1 ||:
+  sudo umount /mnt/sdc1 ||:
   Sirene
 else
-  sudo umount /mnt/sdb1
+  sudo umount /mnt/sdb1 ||:
+  sudo umount /mnt/sdc1 ||:
 fi
 
 sudo poweroff


### PR DESCRIPTION
Beim  Futro S700 (S26361-K1040-v100) liegt der USB-Stick, warum auch immer, unter /dev/sdc1 — quick&dirty-Anpassung: falls /dev/sdb1 nicht mountbar, /dev/sdc1 mounten.